### PR TITLE
Add global tournament sanctions and match date filter

### DIFF
--- a/Backend/src/routes/publicTorneosRoutes.ts
+++ b/Backend/src/routes/publicTorneosRoutes.ts
@@ -31,6 +31,42 @@ router.get(
   })
 );
 
+// ✅ AGREGAR ESTE ENDPOINT en publicTorneosRoutes.ts
+
+router.get(
+  "/:id/sanciones",
+  [
+    param("id")
+      .isInt()
+      .withMessage("El ID del torneo debe ser un número entero."),
+  ],
+  validateRequest,
+  asyncHandler(async (req, res) => {
+    const { id } = req.params;
+
+    const { rows } = await pool.query(
+      `SELECT 
+        s.id, 
+        TO_CHAR(s.fecha, 'DD/MM/YYYY') as fecha,
+        s.titulo, 
+        s.descripcion, 
+        TO_CHAR(s.fechafin, 'DD/MM/YYYY') as fechafin,
+        CONCAT(j.apellido, ' ', j.nombres) as jugador,
+        e.nombre as equipo
+      FROM sanciones s
+      INNER JOIN jugadores j ON s.idjugador = j.id
+      INNER JOIN wequipos e ON s.idequipo = e.id
+      WHERE s.idtorneo = $1 
+        AND s.fhbaja IS NULL 
+        AND s.codestado = 1
+      ORDER BY s.fecha DESC`,
+      [id]
+    );
+
+    res.json(rows);
+  })
+);
+
 router.get(
   "/partido/:id/ficha",
   [

--- a/WebApp/src/api/torneosPublicService.ts
+++ b/WebApp/src/api/torneosPublicService.ts
@@ -70,3 +70,11 @@ export const getFichaPartido = async (
   );
   return data;
 };
+
+
+export const getSancionesByTorneoId = async (idtorneo: number) => {
+  const { data } = await axios.get(
+    `${API_URL}/api/public/torneos/${idtorneo}/sanciones`
+  );
+  return data;
+};

--- a/WebApp/src/pages/Public/Tournaments/componentes/Sanctions.tsx
+++ b/WebApp/src/pages/Public/Tournaments/componentes/Sanctions.tsx
@@ -5,47 +5,76 @@ interface SanctionsProps {
   sanciones: Sancion[];
 }
 
+// Función para limpiar HTML y extraer solo el texto
+const stripHTML = (html: string): string => {
+  if (!html) return "";
+
+  return html
+    .replace(/<[^>]*>/g, "") // Remover tags HTML
+    .replace(/&nbsp;/g, " ") // Reemplazar &nbsp; con espacios
+    .replace(/&amp;/g, "&") // Reemplazar &amp; con &
+    .replace(/&lt;/g, "<") // Reemplazar &lt; con <
+    .replace(/&gt;/g, ">") // Reemplazar &gt; con >
+    .replace(/&quot;/g, '"') // Reemplazar &quot; con "
+    .replace(/&#039;/g, "'") // Reemplazar &#039; con '
+    .replace(/\s+/g, " ") // Normalizar espacios
+    .trim();
+};
+
 const Sanctions: React.FC<SanctionsProps> = ({ sanciones }) => {
-  const visibleSanciones = sanciones.slice(0, 6);
-
   return (
-    <div className="h-[288px] border border-gray-300 rounded-lg shadow-md text-sm bg-white">
-      <div className="p-4 border-b font-semibold bg-gray-50 text-gray-700">
-        SANCIONES
-      </div>
+    <div className="mb-10">
+      <h2 className="text-lg font-bold text-center mb-4">SANCIONES</h2>
 
-      <div className="h-[240px] overflow-y-auto px-4 py-2 space-y-4">
-        {visibleSanciones.length === 0 ? (
-          <p className="text-gray-500 italic">No hay sanciones registradas.</p>
-        ) : (
-          visibleSanciones.map((s, idx) => (
-            <div
-              key={s.id ?? idx}
-              className="border-b border-gray-200 pb-2 last:border-none"
-            >
-              <p className="mb-1">
-                <strong>JUGADOR:</strong> {s.jugador}
-              </p>
-              <p className="mb-1">
-                <strong>EQUIPO:</strong> {s.equipo}
-              </p>
-              <p className="mb-1">
-                <strong>FECHA:</strong> {s.fecha}
-              </p>
-              {s.titulo && (
-                <p className="mb-1">
-                  <strong>{s.titulo.toUpperCase()}</strong>
-                </p>
-              )}
-              {s.descripcion && (
-                <p className="text-gray-700 whitespace-pre-line break-words">
-                  {s.descripcion}
-                </p>
-              )}
-            </div>
-          ))
-        )}
-      </div>
+      {sanciones.length === 0 ? (
+        <div className="text-center text-gray-500 py-8 border border-gray-300 rounded-lg bg-white">
+          No hay sanciones registradas para este torneo.
+        </div>
+      ) : (
+        <div className="h-[400px] border border-gray-300 rounded-lg shadow-md bg-white">
+          <div className="h-full overflow-y-auto p-4 space-y-4">
+            {sanciones.map((sancion) => (
+              <div
+                key={sancion.id}
+                className="border border-gray-200 rounded-lg p-4 bg-gray-50 shadow-sm"
+              >
+                <div className="mb-2">
+                  <strong>JUGADOR:</strong>{" "}
+                  {sancion.jugador || "No especificado"}
+                </div>
+                <div className="mb-2">
+                  <strong>EQUIPO:</strong> {sancion.equipo || "No especificado"}
+                </div>
+                <div className="mb-2">
+                  <strong>FECHA:</strong> {sancion.fecha || "No especificada"}
+                </div>
+                {sancion.titulo && (
+                  <div className="mb-2">
+                    <strong className="text-red-600">
+                      {sancion.titulo.toUpperCase()}
+                    </strong>
+                  </div>
+                )}
+                {sancion.descripcion && (
+                  <div className="text-gray-700 bg-white p-3 rounded border-l-4 border-yellow-500 mt-2">
+                    <div className="whitespace-pre-wrap break-words text-sm">
+                      {stripHTML(sancion.descripcion)}
+                    </div>
+                  </div>
+                )}
+                {sancion.fechafin && (
+                  <div className="mt-3 p-2 bg-red-50 border border-red-200 rounded">
+                    <strong className="text-red-600">
+                      Sanción vigente hasta:
+                    </strong>{" "}
+                    <span className="font-medium">{sancion.fechafin}</span>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Introduces a new backend endpoint to fetch sanctions by tournament, adds frontend API integration and displays sanctions in the public tournament view. Enhances the matches table with filtering and pagination by match date (nrofecha), improving user navigation and visibility of scheduled matches.