### PR TITLE
Refactor equipo jugadores: roles y tipo de jugador

### DIFF
--- a/WebApp/src/components/equipos/Jugadores.tsx
+++ b/WebApp/src/components/equipos/Jugadores.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import JugadorAutocomplete from "../forms/JugadorAutocomplete";
 import { StatusMessage } from "../common";
-import { DataTable, equipoJugadoresColumns } from "..";
+import DataTable from "../tables/DataTable";
+import { createEquipoJugadoresColumns } from "../tables/columns/equipoJugadoresColumns";
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState } from "../../store";
 import { EquipoJugador } from "../../types/equiposJugadores";
@@ -16,7 +17,7 @@ interface EquiposJugadoresProps {
   idequipo: number;
 }
 
-function EquiposJugadores({ idequipo }: EquiposJugadoresProps) {
+const EquiposJugadores = ({ idequipo }: EquiposJugadoresProps) => {
   const dispatch = useDispatch<AppDispatch>();
   const { user } = useSelector((state: RootState) => state.auth);
   const { equiposJugadores, loading, error } = useSelector(
@@ -24,6 +25,7 @@ function EquiposJugadores({ idequipo }: EquiposJugadoresProps) {
   );
 
   const [selectedJugadorId, setSelectedJugadorId] = useState<number>(0);
+  const [selectedCodTipo, setSelectedCodTipo] = useState<number>(1); // Por defecto OFICIAL
 
   useEffect(() => {
     dispatch(fetchEquipoJugadoresByEquipo(idequipo));
@@ -40,14 +42,16 @@ function EquiposJugadores({ idequipo }: EquiposJugadoresProps) {
         saveEquipoJugadorThunk({
           idjugador: selectedJugadorId,
           idequipo,
-          capitan: false,
-          subcapitan: false,
+          capitan: 0, // Inicialmente no es capitán
+          subcapitan: 0, // Inicialmente no es subcapitán
+          codtipo: selectedCodTipo, // OFICIAL o INVITADO
           codestado: 1,
           idusuario: user?.idusuario ?? 0,
         })
       ).unwrap();
       dispatch(fetchEquipoJugadoresByEquipo(idequipo));
       setSelectedJugadorId(0);
+      setSelectedCodTipo(1); // Reset a OFICIAL
     } catch (error) {
       console.error("Error al agregar jugador:", error);
     }
@@ -60,17 +64,57 @@ function EquiposJugadores({ idequipo }: EquiposJugadoresProps) {
 
   const handleToggleCapitan = async (jugador: EquipoJugador) => {
     try {
-      await dispatch(
-        saveEquipoJugadorThunk({
-          id: jugador.id,
-          idjugador: jugador.idjugador,
-          idequipo,
-          capitan: !jugador.capitan,
-          subcapitan: false,
-          codestado: jugador.codestado ?? 1,
-          idusuario: user?.idusuario ?? 0,
-        })
-      ).unwrap();
+      const esCapitanActual = jugador.capitan === 1;
+
+      if (esCapitanActual) {
+        // Si ya es capitán, lo quitamos
+        await dispatch(
+          saveEquipoJugadorThunk({
+            id: jugador.id,
+            idjugador: jugador.idjugador,
+            idequipo,
+            capitan: 0,
+            subcapitan: jugador.subcapitan ?? 0,
+            codtipo: jugador.codtipo ?? 1,
+            codestado: jugador.codestado ?? 1,
+            idusuario: user?.idusuario ?? 0,
+          })
+        ).unwrap();
+      } else {
+        // Lo hacemos capitán: primero quitar capitán actual (si hay) y después asignar
+
+        // 1. Quitar capitán actual
+        const capitanActual = equiposJugadores.find((j) => j.capitan === 1);
+        if (capitanActual) {
+          await dispatch(
+            saveEquipoJugadorThunk({
+              id: capitanActual.id,
+              idjugador: capitanActual.idjugador,
+              idequipo,
+              capitan: 0,
+              subcapitan: capitanActual.subcapitan ?? 0,
+              codtipo: capitanActual.codtipo ?? 1,
+              codestado: capitanActual.codestado ?? 1,
+              idusuario: user?.idusuario ?? 0,
+            })
+          ).unwrap();
+        }
+
+        // 2. Asignar nuevo capitán (y asegurar que no sea subcapitán)
+        await dispatch(
+          saveEquipoJugadorThunk({
+            id: jugador.id,
+            idjugador: jugador.idjugador,
+            idequipo,
+            capitan: 1,
+            subcapitan: 0, // Un capitán no puede ser subcapitán
+            codtipo: jugador.codtipo ?? 1,
+            codestado: jugador.codestado ?? 1,
+            idusuario: user?.idusuario ?? 0,
+          })
+        ).unwrap();
+      }
+
       dispatch(fetchEquipoJugadoresByEquipo(idequipo));
     } catch (error) {
       console.error("Error al cambiar capitán:", error);
@@ -79,32 +123,119 @@ function EquiposJugadores({ idequipo }: EquiposJugadoresProps) {
 
   const handleToggleSubcapitan = async (jugador: EquipoJugador) => {
     try {
-      await dispatch(
-        saveEquipoJugadorThunk({
-          id: jugador.id,
-          idjugador: jugador.idjugador,
-          idequipo,
-          capitan: false,
-          subcapitan: !jugador.subcapitan,
-          codestado: jugador.codestado ?? 1,
-          idusuario: user?.idusuario ?? 0,
-        })
-      ).unwrap();
+      const esSubcapitanActual = jugador.subcapitan === 1;
+
+      if (esSubcapitanActual) {
+        // Si ya es subcapitán, lo quitamos
+        await dispatch(
+          saveEquipoJugadorThunk({
+            id: jugador.id,
+            idjugador: jugador.idjugador,
+            idequipo,
+            capitan: jugador.capitan ?? 0,
+            subcapitan: 0,
+            codtipo: jugador.codtipo ?? 1,
+            codestado: jugador.codestado ?? 1,
+            idusuario: user?.idusuario ?? 0,
+          })
+        ).unwrap();
+      } else {
+        // Lo hacemos subcapitán: primero quitar subcapitán actual (si hay) y después asignar
+
+        // 1. Quitar subcapitán actual
+        const subcapitanActual = equiposJugadores.find(
+          (j) => j.subcapitan === 1
+        );
+        if (subcapitanActual) {
+          await dispatch(
+            saveEquipoJugadorThunk({
+              id: subcapitanActual.id,
+              idjugador: subcapitanActual.idjugador,
+              idequipo,
+              capitan: subcapitanActual.capitan ?? 0,
+              subcapitan: 0,
+              codtipo: subcapitanActual.codtipo ?? 1,
+              codestado: subcapitanActual.codestado ?? 1,
+              idusuario: user?.idusuario ?? 0,
+            })
+          ).unwrap();
+        }
+
+        // 2. Asignar nuevo subcapitán (y asegurar que no sea capitán)
+        await dispatch(
+          saveEquipoJugadorThunk({
+            id: jugador.id,
+            idjugador: jugador.idjugador,
+            idequipo,
+            capitan: 0, // Un subcapitán no puede ser capitán
+            subcapitan: 1,
+            codtipo: jugador.codtipo ?? 1,
+            codestado: jugador.codestado ?? 1,
+            idusuario: user?.idusuario ?? 0,
+          })
+        ).unwrap();
+      }
+
       dispatch(fetchEquipoJugadoresByEquipo(idequipo));
     } catch (error) {
       console.error("Error al cambiar subcapitán:", error);
     }
   };
 
+  const handleToggleCodTipo = async (jugador: EquipoJugador) => {
+    try {
+      const nuevoCodTipo = jugador.codtipo === 1 ? 2 : 1; // Toggle OFICIAL/INVITADO
+      await dispatch(
+        saveEquipoJugadorThunk({
+          id: jugador.id,
+          idjugador: jugador.idjugador,
+          idequipo,
+          capitan: jugador.capitan ?? 0,
+          subcapitan: jugador.subcapitan ?? 0,
+          codtipo: nuevoCodTipo,
+          codestado: jugador.codestado ?? 1,
+          idusuario: user?.idusuario ?? 0,
+        })
+      ).unwrap();
+      dispatch(fetchEquipoJugadoresByEquipo(idequipo));
+    } catch (error) {
+      console.error("Error al cambiar tipo de jugador:", error);
+    }
+  };
+
+  // Crear las columnas con las funciones de callback
+  const columnsWithActions = createEquipoJugadoresColumns({
+    onToggleCapitan: handleToggleCapitan,
+    onToggleSubcapitan: handleToggleSubcapitan,
+    onToggleCodTipo: handleToggleCodTipo,
+  });
+
+  // Ordenar jugadores alfabéticamente por nombre
+  const jugadoresOrdenados = [...equiposJugadores].sort((a, b) => {
+    const nombreA = (a.nombre || a.nombres || "").toLowerCase();
+    const nombreB = (b.nombre || b.nombres || "").toLowerCase();
+    return nombreA.localeCompare(nombreB);
+  });
+
   return (
     <div className="space-y-4">
-      {/* ✅ Componente JugadorAutocomplete reemplazando el select */}
+      {/* Formulario para agregar jugador */}
       <div className="flex items-center gap-4">
         <div className="flex-1">
           <JugadorAutocomplete
             value={selectedJugadorId}
             onChange={(jugador) => setSelectedJugadorId(jugador.id ?? 0)}
           />
+        </div>
+        <div className="flex-shrink-0">
+          <select
+            value={selectedCodTipo}
+            onChange={(e) => setSelectedCodTipo(Number(e.target.value))}
+            className="border rounded px-3 py-2 text-sm"
+          >
+            <option value={1}>OFICIAL</option>
+            <option value={2}>INVITADO</option>
+          </select>
         </div>
         <button
           type="button"
@@ -118,17 +249,35 @@ function EquiposJugadores({ idequipo }: EquiposJugadoresProps) {
       <StatusMessage loading={loading} error={error} />
 
       <DataTable<EquipoJugador>
-        columns={equipoJugadoresColumns}
-        data={equiposJugadores}
-        onEdit={(jugador) =>
-          jugador.capitan
-            ? handleToggleCapitan(jugador)
-            : handleToggleSubcapitan(jugador)
-        }
+        columns={columnsWithActions}
+        data={jugadoresOrdenados}
         onDelete={handleDelete}
       />
+
+      {/* INFO: Resumen del equipo */}
+      <div className="mt-4 text-sm text-gray-600">
+        <p>
+          <strong>Total jugadores:</strong> {equiposJugadores.length} |{" "}
+          <strong>Oficiales:</strong>{" "}
+          {equiposJugadores.filter((j) => j.codtipo === 1).length} |{" "}
+          <strong>Invitados:</strong>{" "}
+          {equiposJugadores.filter((j) => j.codtipo === 2).length}
+        </p>
+        {equiposJugadores.find((j) => j.capitan === 1) && (
+          <p>
+            <strong>Capitán:</strong>{" "}
+            {equiposJugadores.find((j) => j.capitan === 1)?.nombres}
+          </p>
+        )}
+        {equiposJugadores.find((j) => j.subcapitan === 1) && (
+          <p>
+            <strong>Subcapitán:</strong>{" "}
+            {equiposJugadores.find((j) => j.subcapitan === 1)?.nombres}
+          </p>
+        )}
+      </div>
     </div>
   );
-}
+};
 
 export default EquiposJugadores;

--- a/WebApp/src/components/tables/columns/equipoJugadoresColumns.tsx
+++ b/WebApp/src/components/tables/columns/equipoJugadoresColumns.tsx
@@ -1,40 +1,127 @@
 import { EquipoJugador } from "../../../types/equiposJugadores";
 
-export const equipoJugadoresColumns = [
+interface ColumnProps {
+  onToggleCapitan?: (jugador: EquipoJugador) => void;
+  onToggleSubcapitan?: (jugador: EquipoJugador) => void;
+  onToggleCodTipo?: (jugador: EquipoJugador) => void;
+}
+
+export const createEquipoJugadoresColumns = ({
+  onToggleCapitan,
+  onToggleSubcapitan,
+  onToggleCodTipo,
+}: ColumnProps = {}) => [
   {
     header: "Nombre",
+    accessor: "nombres" as keyof EquipoJugador,
+    sortable: true,
     render: (jugador: EquipoJugador) =>
-      `${jugador.nombres} ${jugador.apellido}`,
+      `${jugador.nombres || ""} ${jugador.apellido || ""}`.trim() || "—",
   },
   {
     header: "DNI",
     accessor: "docnro" as keyof EquipoJugador,
+    sortable: true,
+    render: (jugador: EquipoJugador) =>
+      jugador.docnro ? jugador.docnro.toString() : "—",
   },
   {
     header: "N° Camiseta",
     accessor: "camiseta" as keyof EquipoJugador,
+    sortable: true,
     render: (jugador: EquipoJugador) =>
       jugador.camiseta !== null && jugador.camiseta !== undefined
-        ? jugador.camiseta
+        ? jugador.camiseta.toString()
         : "—",
   },
   {
     header: "Tipo",
     accessor: "codtipo" as keyof EquipoJugador,
+    sortable: true,
     render: (jugador: EquipoJugador) => {
-      if (jugador.codtipo === 1) return "OFICIAL";
-      if (jugador.codtipo === 2) return "INVITADO";
-      return "—";
+      const esOficial = jugador.codtipo === 1;
+      return onToggleCodTipo ? (
+        <button
+          onClick={() => onToggleCodTipo(jugador)}
+          className={`px-2 py-1 rounded text-xs font-medium ${
+            esOficial
+              ? "bg-blue-100 text-blue-800 hover:bg-blue-200"
+              : "bg-purple-100 text-purple-800 hover:bg-purple-200"
+          }`}
+          title="Click para cambiar tipo"
+        >
+          {esOficial ? "OFICIAL" : "INVITADO"}
+        </button>
+      ) : (
+        <span
+          className={`px-2 py-1 rounded text-xs ${
+            esOficial
+              ? "bg-blue-100 text-blue-800"
+              : "bg-purple-100 text-purple-800"
+          }`}
+        >
+          {esOficial ? "OFICIAL" : "INVITADO"}
+        </span>
+      );
     },
   },
   {
     header: "Capitán",
     accessor: "capitan" as keyof EquipoJugador,
-    render: (jugador: EquipoJugador) => (jugador.capitan ? "✅" : "—"),
+    sortable: true,
+    render: (jugador: EquipoJugador) => {
+      const esCapitan = jugador.capitan === 1;
+      return onToggleCapitan ? (
+        <button
+          onClick={() => onToggleCapitan(jugador)}
+          className={`px-2 py-1 rounded text-xs font-medium ${
+            esCapitan
+              ? "bg-green-500 text-white hover:bg-green-600"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+          title={
+            esCapitan ? "Click para quitar capitán" : "Click para hacer capitán"
+          }
+        >
+          {esCapitan ? "✅ SÍ" : "NO"}
+        </button>
+      ) : esCapitan ? (
+        "✅"
+      ) : (
+        "—"
+      );
+    },
   },
   {
     header: "Subcapitán",
     accessor: "subcapitan" as keyof EquipoJugador,
-    render: (jugador: EquipoJugador) => (jugador.subcapitan ? "✅" : "—"),
+    sortable: true,
+    render: (jugador: EquipoJugador) => {
+      const esSubcapitan = jugador.subcapitan === 1;
+      return onToggleSubcapitan ? (
+        <button
+          onClick={() => onToggleSubcapitan(jugador)}
+          className={`px-2 py-1 rounded text-xs font-medium ${
+            esSubcapitan
+              ? "bg-orange-500 text-white hover:bg-orange-600"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+          title={
+            esSubcapitan
+              ? "Click para quitar subcapitán"
+              : "Click para hacer subcapitán"
+          }
+        >
+          {esSubcapitan ? "✅ SÍ" : "NO"}
+        </button>
+      ) : esSubcapitan ? (
+        "✅"
+      ) : (
+        "—"
+      );
+    },
   },
 ];
+
+// Export de compatibilidad (sin funcionalidad de botones)
+export const equipoJugadoresColumns = createEquipoJugadoresColumns();

--- a/WebApp/src/types/equiposJugadores.d.ts
+++ b/WebApp/src/types/equiposJugadores.d.ts
@@ -3,8 +3,8 @@ export interface EquipoJugador {
   idjugador: number;
   idequipo: number;
   camiseta?: number;
-  capitan?: boolean;
-  subcapitan?: boolean;
+  capitan?: number; // Cambiado de boolean a number (0 o 1)
+  subcapitan?: number; // Cambiado de boolean a number (0 o 1)
   codtipo?: number;
   codestado?: number;
   fhcarga?: string;
@@ -12,17 +12,19 @@ export interface EquipoJugador {
   idusuario: number;
   apellido?: string;
   nombres?: string;
+  nombre?: string; // Agregado para el ordenamiento
   docnro?: number;
   tipo_desc?: string;
   [key: string]: unknown;
 }
 
 export interface EquipoJugadorInput {
+  id?: number; // Agregado para las actualizaciones
   idjugador: number;
   idequipo: number;
   camiseta?: number;
-  capitan?: boolean;
-  subcapitan?: boolean;
+  capitan?: number; // Cambiado de boolean a number (0 o 1)
+  subcapitan?: number; // Cambiado de boolean a number (0 o 1)
   codtipo?: number;
   codestado?: number;
   idusuario: number;


### PR DESCRIPTION
Actualiza la lógica de capitán y subcapitán para asegurar unicidad y exclusión mutua, permitiendo alternar entre OFICIAL e INVITADO desde la tabla. Cambia los tipos capitan/subcapitan de boolean a number en los tipos, agrega ordenamiento alfabético y muestra resumen de roles en el equipo. Las columnas de la tabla ahora permiten acciones directas sobre los roles y tipo de jugador.